### PR TITLE
FibonacciHeap collection: heap with great amortized operation cost

### DIFF
--- a/src/collections/fibonacci_heap/element.rs
+++ b/src/collections/fibonacci_heap/element.rs
@@ -1,0 +1,124 @@
+use std::{
+    mem::MaybeUninit,
+    ops::{Deref, DerefMut},
+    rc::Rc,
+};
+
+use inner::*;
+
+use super::HeapKey;
+
+pub type FibonacciHeapElementWrapper<T> = Rc<FibonacciHeapElementInner<T>>;
+pub type FibonacciHeapElementPointer<T> = Option<FibonacciHeapElement<T>>;
+
+pub struct FibonacciHeapElement<T>(pub(super) FibonacciHeapElementWrapper<T>)
+where
+    T: HeapKey;
+
+impl<T> Clone for FibonacciHeapElement<T>
+where
+    T: HeapKey,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: HeapKey> Deref for FibonacciHeapElement<T> {
+    type Target = FibonacciHeapElementInner<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+impl<T: HeapKey> DerefMut for FibonacciHeapElement<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(Rc::as_ptr(&self.0) as *mut _) }
+    }
+}
+
+static RC_COUNTER: usize = 0;
+
+pub mod inner {
+    use super::*;
+
+    impl<T: HeapKey> FibonacciHeapElement<T> {
+        pub fn new(key: T) -> FibonacciHeapElement<T> {
+            let id = RC_COUNTER;
+            let mut elem = Self(Rc::new(FibonacciHeapElementInner::new(id, key)));
+
+            let elem_clone = elem.clone();
+            elem.right.write(elem_clone.clone());
+            elem.left.write(elem_clone);
+
+            elem
+        }
+    }
+
+    pub struct FibonacciHeapElementInner<T: HeapKey> {
+        id: usize,
+
+        pub(in crate::collections::fibonacci_heap) key: Option<T>,
+
+        pub(in crate::collections::fibonacci_heap) degree: usize,
+        pub(in crate::collections::fibonacci_heap) mark: bool,
+
+        pub(in crate::collections::fibonacci_heap) parent: FibonacciHeapElementPointer<T>,
+        pub(in crate::collections::fibonacci_heap) child: FibonacciHeapElementPointer<T>,
+        pub(in crate::collections::fibonacci_heap) right: MaybeUninit<FibonacciHeapElement<T>>,
+        pub(in crate::collections::fibonacci_heap) left: MaybeUninit<FibonacciHeapElement<T>>,
+    }
+
+    impl<T: HeapKey> FibonacciHeapElementInner<T> {
+        fn new(id: usize, key: T) -> Self {
+            Self {
+                id,
+                key: Some(key),
+                degree: 0,
+                mark: false,
+                parent: None,
+                child: None,
+                right: MaybeUninit::uninit(),
+                left: MaybeUninit::uninit(),
+            }
+        }
+    }
+
+    impl<T: HeapKey> PartialEq for FibonacciHeapElement<T> {
+        fn eq(&self, other: &Self) -> bool {
+            self.key.eq(&other.key)
+        }
+    }
+
+    impl<T> PartialOrd for FibonacciHeapElement<T>
+    where
+        T: HeapKey,
+    {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            self.key.partial_cmp(&other.key)
+        }
+    }
+}
+
+pub mod reference {
+    use std::{cell::RefCell, rc::Weak};
+
+    use crate::collections::fibonacci_heap::{FibonacciHeap, FibonacciHeapInner};
+
+    use super::*;
+
+    pub struct FibHeapRef<T: HeapKey> {
+        element: FibonacciHeapElement<T>,
+        heap: Weak<RefCell<FibonacciHeapInner<T>>>,
+    }
+
+    impl<T: HeapKey> FibHeapRef<T> {
+        pub fn from_elem(elem: &FibonacciHeapElement<T>, heap: &FibonacciHeap<T>) -> Self {
+            Self {
+                element: elem.clone(),
+                heap: Rc::downgrade(&heap.0),
+            }
+        }
+    }
+}

--- a/src/collections/fibonacci_heap/error.rs
+++ b/src/collections/fibonacci_heap/error.rs
@@ -1,0 +1,11 @@
+use std::cell::BorrowMutError;
+
+pub enum HeapReferenceError {
+    RecursiveExclusiveAccess,
+}
+
+impl From<BorrowMutError> for HeapReferenceError {
+    fn from(_: BorrowMutError) -> Self {
+        Self::RecursiveExclusiveAccess
+    }
+}

--- a/src/collections/fibonacci_heap/inner.rs
+++ b/src/collections/fibonacci_heap/inner.rs
@@ -1,0 +1,120 @@
+use super::*;
+pub struct FibonacciHeapInner<T: HeapKey> {
+    h_min: FibonacciHeapElementPointer<T>,
+    size: usize,
+
+    name: String,
+}
+#[allow(unreachable_code)]
+impl<T: HeapKey> FibonacciHeapInner<T> {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            h_min: None,
+            size: 0,
+            name: name.into(),
+        }
+    }
+
+    pub fn insert(&mut self, value: T, heap_ref: &FibonacciHeap<T>) -> FibHeapRef<T> {
+        let mut new_elem = FibonacciHeapElement::new(value);
+
+        let new_elem_ref = FibHeapRef::from_elem(&new_elem, heap_ref);
+
+        if let Some(h_min) = &mut self.h_min {
+            // todo!("Add new_elem to root list");
+
+            Self::ll_insert_left(h_min, &mut new_elem);
+
+            if new_elem.key < h_min.key {
+                let _ = self.h_min.replace(new_elem);
+            }
+        } else {
+            assert!(self.empty());
+            // todo!("Create new root list with new_elem!");
+            let _ = self.h_min.insert(new_elem);
+        }
+
+        self.size += 1;
+
+        new_elem_ref
+    }
+
+    pub fn min(&self, heap_ref: &FibonacciHeap<T>) -> Option<FibHeapRef<T>> {
+        self.h_min
+            .as_ref()
+            .map(|h_min| FibHeapRef::from_elem(h_min, heap_ref))
+    }
+
+    pub fn union(&mut self, other: FibonacciHeap<T>) {
+        //todo!("Append root list of other to own root list");
+
+        if let Some(other) = Rc::into_inner(other.0) {
+            let mut other = other.into_inner();
+            match &mut self.h_min {
+                Some(h_min_self) => {
+                    if let Some(mut h_min_other) = other.h_min.take() {
+                        Self::ll_insert_left(h_min_self, &mut h_min_other);
+                        if *h_min_self < h_min_other {
+                            let _ = self.h_min.replace(h_min_other);
+                        }
+                    }
+
+                    self.size += other.size;
+                }
+                None => {
+                    // self heap is empty
+                    if other.h_min.is_some() {
+                        let name = self.name.clone();
+                        *self = other;
+                        self.name = name;
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn extract_min(&mut self) -> Option<T> {
+        self.h_min.take().map(|mut z| {
+            // todo!("For all children x of z: add x to root list, x.parent = NULL");
+            self.h_min = z.child.take();
+
+            if let Some(child) = &mut self.h_min {
+                let mut cur_child = unsafe { &mut *child.right.as_mut_ptr() };
+                loop {
+                    let _ = cur_child.parent.take();
+                    if Rc::<_>::ptr_eq(&cur_child.0, &child.0) {
+                        cur_child.parent.take();
+                        break;
+                    }
+                    cur_child = unsafe { &mut *cur_child.right.as_mut_ptr() };
+                }
+            }
+
+            z.key.take().unwrap()
+        })
+    }
+
+    fn ll_insert_left(
+        ll_node: &mut FibonacciHeapElement<T>,
+        new_node: &mut FibonacciHeapElement<T>,
+    ) {
+        unsafe {
+            new_node.right.assume_init_drop();
+            new_node.left.assume_init_drop();
+        };
+
+        let ll_left = unsafe { ll_node.left.assume_init_read() };
+        ll_node.left.write(new_node.clone());
+
+        new_node.right.write(ll_node.clone());
+        new_node.left.write(ll_left);
+    }
+
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    pub fn empty(&self) -> bool {
+        self.size == 0
+    }
+}

--- a/src/collections/fibonacci_heap/mod.rs
+++ b/src/collections/fibonacci_heap/mod.rs
@@ -1,0 +1,38 @@
+use std::{cell::RefCell, rc::Rc};
+
+pub mod error;
+use error::HeapReferenceError;
+
+pub mod element;
+pub use element::reference::FibHeapRef;
+use element::*;
+
+mod inner;
+use inner::*;
+
+pub trait HeapKey: PartialOrd {}
+impl<T: PartialOrd + PartialEq> HeapKey for T {}
+
+pub struct FibonacciHeap<T: HeapKey>(Rc<RefCell<FibonacciHeapInner<T>>>);
+
+impl<T: HeapKey> Clone for FibonacciHeap<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: HeapKey> FibonacciHeap<T> {
+    pub fn new(name: impl Into<String>) -> FibonacciHeap<T> {
+        FibonacciHeap(Rc::new(RefCell::new(FibonacciHeapInner::new(name))))
+    }
+
+    pub fn with_inner<F, R>(&mut self, f: F) -> Result<R, HeapReferenceError>
+    where
+        F: FnOnce(&mut FibonacciHeapInner<T>) -> R,
+    {
+        match self.0.try_borrow_mut() {
+            Ok(ref mut heap) => Ok(f(heap)),
+            Err(error) => Err(error.into()),
+        }
+    }
+}

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -1,0 +1,1 @@
+pub mod fibonacci_heap;


### PR DESCRIPTION
Fibonacci heaps offer great performances (in theory, through amortization):
- Creation: O(1)
- Insertion: O(1)
- Union: O(1)
- ...

Features:
- insert elements into heap
- decrease the key of a given heap element in constant time
- merge two heaps in constant time

API (generic over data type T):
- [ ] `new()`: create a new heap
- [ ] `insert(v: T) -> HeapElementRef`: insert an item into the heap; return a reference to that item to allow constant time DecreaseKey
- [ ] `minimum() -> &Option<T>`: peek at the min. element in the heap
- [ ] `extract_min() -> Option<T>`: extract the minimum element from the heap if the heap isn't empty
- [ ] `union(other: FibHeap)`: merge heap `other` into `self`
- [ ] `decrease_key(ref: HeapElementRef, newkey)`: decrease the key of referenced element
- [ ] `delete(ref: HeapElementRef) -> Option<T>`: remove the given element from the heap
- [ ] <Placeholder for future additions to API>